### PR TITLE
Force consul stop to run ASAP on shutdown

### DIFF
--- a/templates/etc/init.d/consul.Debian.j2
+++ b/templates/etc/init.d/consul.Debian.j2
@@ -1,8 +1,8 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          consul
-# Required-Start:    $local_fs $remote_fs
-# Required-Stop:     $local_fs $remote_fs
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      S 0 1 6
 # Short-Description: Consul service discovery framework

--- a/templates/etc/init.d/consul.RedHat.j2
+++ b/templates/etc/init.d/consul.RedHat.j2
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # consul        Manage the consul agent
-#       
-# chkconfig:   2345 95 95
+#
+# chkconfig:   0123456 95 01
 # description: Consul is a tool for service discovery and configuration
 # processname: consul
 # config: /etc/consul.d
@@ -39,7 +39,7 @@ export GOMAXPROCS=${GOMAXPROCS:-2}
 
 start() {
     [ -x $exec ] || exit 5
-    
+
     [ -d $confdir ] || exit 6
 
     umask 077
@@ -48,7 +48,7 @@ start() {
     chown $user:$user $logfile $pidfile
 
     echo -n $"Starting $prog: "
-    
+
     ## holy shell shenanigans, batman!
     ## daemon can't be backgrounded.  we need the pid of the spawned process,
     ## which is actually done via runuser thanks to --user.  you can't do "cmd
@@ -57,12 +57,12 @@ start() {
         --pidfile=$pidfile \
         --user=consul \
         " { $exec ${DAEMON_ARGS} ${CONSUL_OPTS} &>> $logfile & } ; echo \$! >| $pidfile "
-    
+
     RETVAL=$?
     echo
-    
+
     [ $RETVAL -eq 0 ] && touch $lockfile
-    
+
     return $RETVAL
 }
 

--- a/templates/etc/init.d/consul.RedHat.j2
+++ b/templates/etc/init.d/consul.RedHat.j2
@@ -2,7 +2,7 @@
 #
 # consul        Manage the consul agent
 #
-# chkconfig:   0123456 95 01
+# chkconfig:   2345 95 85
 # description: Consul is a tool for service discovery and configuration
 # processname: consul
 # config: /etc/consul.d


### PR DESCRIPTION
since the termination/shutdown process of the ec2 instances is too fast, we need to force that the consul stop is run as soon as possible.