### PR TITLE
Upgrade consul to 0.9.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ consul_ui_package_dest: "{{consul_package_dest}}"
 
 consul_ui_dir: /opt/consul/ui
 
-consul_ui_enabled: false
+consul_legacy_ui_enabled: false
 
 # Start consul at boot time
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ consul_group: consul
 # Create the consul user and group
 consul_create_user: true
 
-consul_version: 0.7.0
+consul_version: 0.9.0
 
 consul_bin:  /usr/local/bin/consul
 consul_dest: "/opt/consul/{{consul_version}}"
@@ -64,4 +64,3 @@ consul_data_dir: /var/consul
 consul_config: {}
 
 # vi:ts=2:sw=2:et:ft=yaml
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,8 @@
   tags: consul_install
 
 - include: ui.yml
-  when: consul_ui_enabled
-  tags: consul_ui
+  when: consul_legacy_ui_enabled
+  tags: consul_legacy_ui
 
 - include: config.yml
   tags: consul_config


### PR DESCRIPTION
Since the UI separate package has been deprecated, the whole ui tasks should now be marked as legacy to ensure is not run unless needed (for a pre-0.8.0 installation)