### PR TITLE
Add support for logrotate configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,19 @@ consul_start_at_boot: true
 # clean start (nothing in the data dir)
 consul_started: true
 
+# Disable by default the installation of consul's logrotate config file
+consul_logrotate_enabled: false
+consul_logrotate_config: |
+  /var/log/consul.log {
+    create 0644 {{consul_user}} {{consul_group}}
+    daily
+    rotate 7
+    delaycompress
+    compress
+    missingok
+    notifempty
+  }
+
 consul_config_dir: /etc/consul.d
 consul_data_dir: /var/consul
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -20,4 +20,13 @@
   with_dict: "{{consul_config}}"
   notify: consul restart
 
+- name: Consul Logrotate configuration
+  template:
+    src: "etc/logrotate.d/consul.j2"
+    dest: "/etc/logrotate.d/consul"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when: consul_logrotate_enabled
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -21,9 +21,9 @@
   notify: consul restart
 
 - name: Consul Logrotate configuration
-  template:
-    src: "etc/logrotate.d/consul.j2"
+  copy:
     dest: "/etc/logrotate.d/consul"
+    contents: "{{consul_logrotate_config}}"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/templates/etc/logrotate.d/consul.j2
+++ b/templates/etc/logrotate.d/consul.j2
@@ -1,1 +1,0 @@
-{{consul_logrotate_config}}

--- a/templates/etc/logrotate.d/consul.j2
+++ b/templates/etc/logrotate.d/consul.j2
@@ -1,0 +1,1 @@
+{{consul_logrotate_config}}


### PR DESCRIPTION
Consul log file could be a little verbose, especially when it have some duplicated id warnings. This PR adds support for install a logrotate configuration to prevent high disk usage on verbose logs.