### PR TITLE
Logrotate fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ consul_logrotate_config: |
     create 0644 {{consul_user}} {{consul_group}}
     daily
     rotate 7
+    copytruncate
     delaycompress
     compress
     missingok

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ consul_started: true
 # Disable by default the installation of consul's logrotate config file
 consul_logrotate_enabled: false
 consul_logrotate_config: |
-  /var/log/consul.log {
+  /var/log/consul {
     create 0644 {{consul_user}} {{consul_group}}
     daily
     rotate 7

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -23,7 +23,7 @@
 - name: Consul Logrotate configuration
   copy:
     dest: "/etc/logrotate.d/consul"
-    contents: "{{consul_logrotate_config}}"
+    content: "{{consul_logrotate_config}}"
     owner: "root"
     group: "root"
     mode: "0644"


### PR DESCRIPTION
This PR fixes some bugs from the previous PR.

* Fix incorrect content parameter in copy module
* Add copytruncate on logrotate as consul agent doesn't have a clean way to reload the file descriptor (neither service reload nor kill with signal HUP/USR1 works)
* Change logrotate log path the one used by consul as default